### PR TITLE
[WIP]: Time zone fix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  around_action :set_time_zone
+  before_filter :set_time_zone
 
 
   include SegmentRails
@@ -18,12 +18,7 @@ class ApplicationController < ActionController::Base
   end
 
 
-  def set_time_zone(&block)
-    if account_signed_in?
-      Time.use_zone(current_account.time_zone, &block)
-    else
-      yield
-    end
+  def set_time_zone
+    Time.zone = current_account.time_zone if current_account
   end
-  private :set_time_zone
 end

--- a/app/helpers/time_zone_helper.rb
+++ b/app/helpers/time_zone_helper.rb
@@ -1,0 +1,5 @@
+def time_zone_options_for_select(selected = nil, priority_zones = nil, model = ::ActiveSupport::TimeZone)
+        zone_options = "".html_safe
+        zones = model.all
+        convert_zones = lambda { |list| list.map { |z| [ z.to_s, z.name ] } }
+end

--- a/app/helpers/time_zone_helper.rb
+++ b/app/helpers/time_zone_helper.rb
@@ -1,5 +1,4 @@
-def time_zone_options_for_select(selected = nil, priority_zones = nil, model = ::ActiveSupport::TimeZone)
-        zone_options = "".html_safe
-        zones = model.all
-        convert_zones = lambda { |list| list.map { |z| [ z.to_s, z.name ] } }
+module TimeZoneHelper
+  def time_zone_options_for_select(_selected = nil, _priority_zones = nil, _model = ::ActiveSupport::TimeZone)
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <%= f.label :time_zone %>
-  <%= f.time_zone_options_for_select :time_zone %>
+  <%= f.time_zone_select :time_zone,  ActiveSupport::TimeZone.all.sort %>
 
   <div class="field">
     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -19,7 +19,7 @@
   <% end %>
 
   <%= f.label :time_zone %>
-  <%= f.time_zone_select :time_zone, ActiveSupport::TimeZone.all.sort %>
+  <%= f.time_zone_options_for_select :time_zone %>
 
   <div class="field">
     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,7 @@
     <%= f.password_field :password, autocomplete: "off" %>
 
     <%= f.label :time_zone %>
-    <%= f.time_zone_select "accounts", :time_zone, ActiveSupport::TimeZone.all.sort %>
+    <%= f.time_zone_select :time_zone, ActiveSupport::TimeZone.all.sort %>
 
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, autocomplete: "off" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,7 @@
     <%= f.password_field :password, autocomplete: "off" %>
 
     <%= f.label :time_zone %>
-    <%= f.time_zone_select :time_zone, ActiveSupport::TimeZone.all.sort %>
+    <%= f.time_zone_select "accounts", :time_zone, ActiveSupport::TimeZone.all.sort %>
 
     <%= f.label :password_confirmation %>
     <%= f.password_field :password_confirmation, autocomplete: "off" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,8 +30,7 @@ module Capacitor
     # config.i18n.load_path += Dir[Rails.root.join("my", "locales", "*.{rb,yml}").to_s]
     # config.i18n.default_locale = :de
 
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.default_timezone = :local
+    # Do not swallaow errors in after_commit/after_rollback callbacks.
     config.beginning_of_week = :sunday
     config.active_record.raise_in_transactional_callbacks = true
     config.encoding = "utf-8"

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,7 @@ module Capacitor
     # config.i18n.default_locale = :de
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
+    config.active_record.default_timezone = :local
     config.beginning_of_week = :sunday
     config.active_record.raise_in_transactional_callbacks = true
     config.encoding = "utf-8"

--- a/db/migrate/20150710084703_change_time_zone_column_in_accounts.rb
+++ b/db/migrate/20150710084703_change_time_zone_column_in_accounts.rb
@@ -1,0 +1,5 @@
+class ChangeTimeZoneColumnInAccounts < ActiveRecord::Migration
+  def change
+     change_column :accounts, :time_zone, :string,  :limit => 255, :default => "UTC", null: false
+  end
+end

--- a/db/migrate/20150710084703_change_time_zone_column_in_accounts.rb
+++ b/db/migrate/20150710084703_change_time_zone_column_in_accounts.rb
@@ -1,5 +1,5 @@
 class ChangeTimeZoneColumnInAccounts < ActiveRecord::Migration
   def change
-     change_column :accounts, :time_zone, :string,  :limit => 255, :default => "UTC", null: false
+    change_column :accounts, :time_zone, :string, limit: 255, default: "UTC", null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,29 +11,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150705174354) do
+ActiveRecord::Schema.define(version: 20150710084703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "accounts", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.string   "name",                     default: "",                           null: false
-    t.string   "email",                    default: "",                           null: false
-    t.uuid     "uuid",                     default: "uuid_generate_v4()"
-    t.string   "encrypted_password",                                              null: false
+    t.string   "name",                                 default: "",                   null: false
+    t.string   "email",                                default: "",                   null: false
+    t.uuid     "uuid",                                 default: "uuid_generate_v4()"
+    t.string   "encrypted_password",                                                  null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",            default: 0,                            null: false
+    t.integer  "sign_in_count",                        default: 0,                    null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                                                      null: false
-    t.datetime "updated_at",                                                      null: false
-    t.integer  "weekly_expected_capacity", default: 0,                            null: false
-    t.string   "time_zone",                default: "Central Time (US & Canada)", null: false
+    t.datetime "created_at",                                                          null: false
+    t.datetime "updated_at",                                                          null: false
+    t.integer  "weekly_expected_capacity",             default: 0,                    null: false
+    t.string   "time_zone",                limit: 255, default: "UTC",                null: false
   end
 
   add_index "accounts", ["created_at"], name: "index_accounts_on_created_at", using: :btree


### PR DESCRIPTION
 reverted back to what I had in the application controller as the `&block` statement that was in there previously was causing an error. 

The error that the rails server prints when you attempt to change the time zone for an account via the app is `Unpermitted parameter: time_zone` research turned up diddly squat on the matter, except the fact that `around_action` was not an acceptable parameter to use. 

@zincmade/capacitor 