### PR TITLE
User may assign teams from project new/edit pages

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,6 +16,7 @@ class ProjectsController < ApplicationController
 
   def edit
     @project = Project.find(params[:id])
+    @teams = Team.all
   end
 
   def update
@@ -30,6 +31,6 @@ class ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:name, :capacity, :weekly_burn_rate, :billable, :active)
+    params.require(:project).permit(:name, :capacity, :weekly_burn_rate, :billable, :active, team_ids: [])
   end
 end

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -24,6 +24,11 @@
     Active?
   <% end %>
 
+  <fieldset>
+    <legend>Teams</legend>
+    <%= collection_check_boxes(:project, :team_ids, Team.all, :id, :name) %>
+  </fieldset>
+
   <%= f.submit submit_text %>
   <%= link_to "Return To Dashboard", root_path %>
 <% end %>

--- a/spec/factories/teams_projects.rb
+++ b/spec/factories/teams_projects.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :teams_project do
+    team
+    project
+  end
+end

--- a/spec/features/creating_project_spec.rb
+++ b/spec/features/creating_project_spec.rb
@@ -3,11 +3,15 @@ require "rails_helper"
 feature "Creating projects" do
   include_context "account login"
 
+  Given!(:team) { FactoryGirl.create(:team, name: "Team A") }
+
   When { click_link_or_button "Create a new project" }
   When { fill_in "Name", with: "Project A" }
   When { fill_in "Capacity", with: 10 }
   When { fill_in "Weekly burn rate", with: 5 }
+  When { check "Team A" }
   When { click_link_or_button "Create project" }
 
   Then { expect(Project.find_by(name: "Project A")).to be_persisted }
+  Then { expect(Project.find_by(name: "Project A").teams).to include(team) }
 end

--- a/spec/features/edit_project_spec.rb
+++ b/spec/features/edit_project_spec.rb
@@ -4,15 +4,24 @@ feature "Edit projects" do
   Given!(:project) { FactoryGirl.create(:project, name: "Project A", capacity: 10) }
   Given!(:decorated_project) { project.decorate }
 
+  Given!(:team_1) { FactoryGirl.create(:team, name: "Team A") }
+  Given!(:team_2) { FactoryGirl.create(:team, name: "Team B") }
+
+  Given!(:assignment_1) { FactoryGirl.create(:teams_project, team: team_1, project: project) }
+
   include_context "account login"
 
   When { within("##{decorated_project.dom_id}") { click_link_or_button "Edit" } }
 
   context "successfully edits project" do
     When { fill_in "Capacity", with: 8 }
+    When { uncheck "Team A" }
+    When { check "Team B" }
     When { click_link_or_button "Save" }
 
     Then { expect(project.reload.capacity).to eql(8) }
+    Then { expect(project.teams).not_to include(team_1) }
+    Then { expect(project.teams).to include(team_2) }
   end
 
   context "unsuccessfully edits project" do


### PR DESCRIPTION
@zincmade/capacitor The task mentioned only on edit, but I also included it on project creation. Is that alright or should it only be on project edit? 

Also still need to make it that only the team owner can edit/add from project